### PR TITLE
Added 'Compiler arguments' field to pass arguments to the compiler

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,12 +14,19 @@ export default {
       default: 'ghdl',
       order: 0,
     },
+    compileArgs: {
+      title: 'Compiler arguments',
+      description: 'Arguments to pass to the compiler',
+      type: 'string',
+      default: '',
+      order: 1,
+    },
     compileOnLint: {
       title: 'Compile on lint',
       description: 'Should the linter compile file when linting (using -a) or just check the syntax (using -s)',
       type: 'boolean',
       default: false,
-      order: 1,
+      order: 2,
     },
   },
   provideLinter() {
@@ -35,12 +42,14 @@ export default {
         const editorPath = textEditor.getPath();
 
         const compiler = atom.config.get('linter-vhdl.vhdlCompiler');
+        const compileArgs = atom.config.get('linter-vhdl.compileArgs');
         const shouldCompile = atom.config.get('linter-vhdl.compileOnLint');
         const command = shouldCompile ? '-a' : '-s';
 
         const options = { cwd: dirname(editorPath) };
         const args = argsRegex.exec(textEditor.getText());
-        const argsString = (args && args.length >= 2) ? args[1] : '';
+        var   argsString = (args && args.length >= 2) ? args[1] : '';
+        argsString=argsString.concat(' ',compileArgs);
 
         const results = [];
 


### PR DESCRIPTION
Hi all, I added a field to pass arguments to the compiler. I've tried it with GHDL on Windows 10, passing 'std=08' and it works well.

I think this is a feature that was desired by some people for a long time.